### PR TITLE
Switch to RNICloudStorage

### DIFF
--- a/RNICloudKeyValueStore.podspec
+++ b/RNICloudKeyValueStore.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.authors      = { "Adrian" => "adrian@nona.digital" }
   s.platform     = :ios, "7.0"
 
-  s.source       = { :git => "httsp://github.com/Nona-Creative/react-native-icloudstore.git" }
+  s.source       = { :git => "https://github.com/Nona-Creative/react-native-icloudstore.git" }
 
   s.source_files  = "*.{h,m}"
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
  * @providesModule react-native-icloud-key-value-store
  */
 
-import { AsyncStorage, NativeModules, Platform } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
+import { AsyncStorage } from '@react-native-community/async-storage';
 
 const iCloudStorage = Platform.OS === 'ios' ? NativeModules.RNICloudKeyValueStore : AsyncStorage;
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 import { NativeModules, Platform } from 'react-native';
 import { AsyncStorage } from '@react-native-community/async-storage';
 
-const iCloudStorage = Platform.OS === 'ios' ? NativeModules.RNICloudKeyValueStore : AsyncStorage;
+const iCloudStorage = Platform.OS === 'ios' ? NativeModules.RNICloudStorage : AsyncStorage;
 
 export default iCloudStorage;
 


### PR DESCRIPTION
Not quite sure the cause of this but when attempting to use this `NativeModules.RNICloudKeyValueStore` is undefined. Switching to `RNICloudStorage` works however.

While there have also imported AsyncStorage from it's own module (deprecated in react-native) and fixed a typo.